### PR TITLE
Renamed the rust library name to ocaml-blake3. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "blake3"
+name = "ocaml-blake3"
 version = "0.1.0"
 authors = ["Yoshihiro Imai <y.imai@proof-ninja.co.jp>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Blake3
 
 An implementation of the [BLAKE3](https://github.com/BLAKE3-team/BLAKE3/) cryptographic hash function.
+
+## Mac OS
+
+If the compilation fails complaining undefined symbols starting with `_caml`, you should add the following to your `$HOME/.cargo/config`:
+
+```
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+```

--- a/blake3.opam
+++ b/blake3.opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "foobar"
+authors: ["foobar"]
+homepage: "https://github.com/proof-ninja/ocaml-blake3"
+bug-reports: "https://github.com/proof-ninja/ocaml-blake3/issues"
+dev-repo: "git+https://github.com/proof-ninja/ocaml-blake3.git"
+license: "foobar"
+
+depends: [
+    "ocaml" {>= "4.09.1"}
+    "dune"
+    "conf-rust" {build}
+]
+
+build: [
+    ["dune" "build" "-p" name]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Blake3 cryptography
+"""

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 2.7)
+(name blake3)

--- a/src/dune
+++ b/src/dune
@@ -1,16 +1,17 @@
 (rule
- (targets libblake3.a dllblake3.so)
+ (targets libocaml_blake3.a dllocaml_blake3.so)
  (deps (glob_files *.rs))
  (action
   (progn
    (run cargo build --target-dir %{project_root}/../../target --release)
    (run sh -c
-     "mv %{project_root}/../../target/release/libblake3.so ./dllblake3.so 2> /dev/null || \
-      mv %{project_root}/../../target/release/libblake3.dylib ./dllblake3.so")
-   (run mv %{project_root}/../../target/release/libblake3.a libblake3.a))))
+     "mv %{project_root}/../../target/release/libocaml_blake3.so ./dllocaml_blake3.so 2> /dev/null || \
+      mv %{project_root}/../../target/release/libocaml_blake3.dylib ./dllocaml_blake3.so")
+   (run mv %{project_root}/../../target/release/libocaml_blake3.a libocaml_blake3.a))))
 
 (library
  (name blake3)
- (foreign_archives blake3)
+ (public_name blake3)
+ (foreign_archives ocaml_blake3)
  (c_library_flags
   (-lpthread -lc -lm)))


### PR DESCRIPTION
Added blake3.opam, though `opam install` fails due to network access in the sandbox.

Added a note in `README.md` about the build in Mac OS.  You need:

```
[target.x86_64-apple-darwin]
rustflags = [
  "-C", "link-arg=-undefined",
  "-C", "link-arg=dynamic_lookup",
]
```

in your `$HOME/.cargo/config`